### PR TITLE
Assign random Id to Elements without Ids when adding Events

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "metron",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronical.metron",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "homepage": "https://github.com/metronical/metron",

--- a/src/metron.extenders.ts
+++ b/src/metron.extenders.ts
@@ -474,6 +474,9 @@ Element.prototype.drop = function(): Element {
 };
 
 Element.prototype.removeEvent = function (event: string): Element {
+    if (this.id == "")
+        return this;
+
     if (metron.globals.handlers[this.id])
     {
         if (metron.globals.handlers[this.id][event])
@@ -491,6 +494,9 @@ Element.prototype.addEvent = function (event: string, callback: Function, overwr
         this.removeEvent(event);
     }
     this.addEventListener(event, callback);
+    if (this.id == "") {
+        this.id = metron.guid.newGuid();
+    }
     if (!metron.globals.handlers[this.id]) {
         metron.globals.handlers[this.id] = {};
     }

--- a/src/metron.ts
+++ b/src/metron.ts
@@ -316,18 +316,14 @@ namespace metron {
         })();
     }
     export namespace guid {
-        (function () {
-            function generateGUIDPart(): string {
-                return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
-            }
-            return {
-                //Note that JavaScript doesn't actually have GUID or UUID functionality.
-                //This is as best as it gets.
-                newGuid: function (): string {
-                    return (generateGUIDPart() + generateGUIDPart() + "-" + generateGUIDPart() + "-" + generateGUIDPart() + "-" + generateGUIDPart() + "-" + generateGUIDPart() + generateGUIDPart() + generateGUIDPart());
-                }
-            };
-        })();
+        function generateGUIDPart(): string {
+            return (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
+        }
+        //Note that JavaScript doesn't actually have GUID or UUID functionality.
+        //This is as best as it gets.
+        export function newGuid(): string {
+            return (generateGUIDPart() + generateGUIDPart() + "-" + generateGUIDPart() + "-" + generateGUIDPart() + "-" + generateGUIDPart() + "-" + generateGUIDPart() + generateGUIDPart() + generateGUIDPart());
+        }
     }
 }
 


### PR DESCRIPTION
All elements with events need a unique Id so we can keep track of them in the globals.handlers.  Related to the bug fix #37 