### PR TITLE
Checking labels exist before trying to add the error class

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "metron",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronical.metron",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "homepage": "https://github.com/metronical/metron",

--- a/src/metron.forms.ts
+++ b/src/metron.forms.ts
@@ -264,7 +264,9 @@ namespace metron {
                     isValid = false;
                     result += `<p>[${elem.attribute("name")}] is a required field.</p>`;
                     elem.addClass("error");
-                    f.selectOne(`label[for='${elem.attribute("id")}']`).addClass("label-error");
+                    if (f.selectOne(`label[for='${elem.attribute("id")}']`) != null) {
+                        f.selectOne(`label[for='${elem.attribute("id")}']`).addClass("label-error");
+                    }
                 }
             });
             if (!isValid) {


### PR DESCRIPTION
When validating a form we should expect that occasionally an input may not have an associated label, so check for a label before trying to add the error class