### PR TITLE
disable save button 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "metron",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronical.metron",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "homepage": "https://github.com/metronical/metron",

--- a/src/metron.forms.ts
+++ b/src/metron.forms.ts
@@ -74,6 +74,7 @@ namespace metron {
                         switch (el.attribute("data-m-action").lower()) {
                             case "save":
                                 el.addEvent("click", function (e) {
+                                    el.attribute("disabled", "disabled");
                                     e.preventDefault();
                                     if (metron.globals.actions != null && metron.globals.actions[`${self.model}_${el.attribute("data-m-action").lower()}`] != null) { //Refactor getting the action overrides
                                         metron.globals.actions[`${self.model}_${el.attribute("data-m-action").lower()}`]();
@@ -93,6 +94,7 @@ namespace metron {
                                                     self.save(data, <number><any>el.attribute("data-m-pivot"))
                                                 }, (txt, jsn, xml) => {
                                                     self.showAlerts(metron.DANGER, txt, jsn, xml);
+                                                    el.removeAttribute("disabled");
                                                 });
                                             }
                                             else {
@@ -100,8 +102,11 @@ namespace metron {
                                                     self.save(data, <number><any>el.attribute("data-m-pivot"));
                                                 }, (txt, jsn, xml) => {
                                                     self.showAlerts(metron.DANGER, txt, jsn, xml);
+                                                    el.removeAttribute("disabled");
                                                 });
                                             }
+                                        } else {
+                                            el.removeAttribute("disabled");
                                         }
                                     }
                                 }, true);


### PR DESCRIPTION
Some users with slow connection click save button multiple times, creating duplicate records.  On click, disable the button right away to prevent that.