### PR TITLE
Enable save buttons just before leaving form

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "metron",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronical.metron",
-  "version": "2.8.8",
+  "version": "2.8.9",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "homepage": "https://github.com/metronical/metron",

--- a/src/metron.forms.ts
+++ b/src/metron.forms.ts
@@ -91,7 +91,7 @@ namespace metron {
                                             });
                                             if (!hasPrimary) {
                                                 metron.web.post(`${metron.fw.getAPIURL(self.model)}`, parameters, null, "json", (data: T) => {
-                                                    self.save(data, <number><any>el.attribute("data-m-pivot"))
+                                                    self.save(data, <number><any>el.attribute("data-m-pivot"), el)
                                                 }, (txt, jsn, xml) => {
                                                     self.showAlerts(metron.DANGER, txt, jsn, xml);
                                                     el.removeAttribute("disabled");
@@ -99,7 +99,7 @@ namespace metron {
                                             }
                                             else {
                                                 metron.web.put(`${metron.fw.getAPIURL(self.model)}`, parameters, null, "json", (data: T) => {
-                                                    self.save(data, <number><any>el.attribute("data-m-pivot"));
+                                                    self.save(data, <number><any>el.attribute("data-m-pivot"), el);
                                                 }, (txt, jsn, xml) => {
                                                     self.showAlerts(metron.DANGER, txt, jsn, xml);
                                                     el.removeAttribute("disabled");
@@ -148,7 +148,7 @@ namespace metron {
             }
             return self;
         }
-        public save(data: T, pivotPosition: number): void {
+        public save(data: T, pivotPosition: number, saveElement: Element): void {
             var self = this;
             self.elem.selectAll("[data-m-primary]").each((idx: number, elem: Element) => {
                 (<HTMLElement>elem).val(<string><any>data[<string><any>elem.attribute("name")]);
@@ -162,6 +162,7 @@ namespace metron {
                 }
                 catch(e) { }
             }
+            saveElement.removeAttribute("disabled");
             if ((<any>self).save_m_inject != null) {
                 (<any>self).save_m_inject(data);
             }


### PR DESCRIPTION
Saving disables save button to prevent multiple submits.  In some situations the save button is not re-enabled when loading a form again.  