### PR TITLE
Allow clearForm to ignore fields

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "metron",
-  "version": "2.8.15",
+  "version": "2.8.16",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronical.metron",
-  "version": "2.8.15",
+  "version": "2.8.16",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "homepage": "https://github.com/metronical/metron",

--- a/src/metron.forms.ts
+++ b/src/metron.forms.ts
@@ -246,13 +246,13 @@ namespace metron {
             document.selectAll(".label-error").each(function (idx, elem) {
                 (<HTMLElement>elem).removeClass("label-error");
             });
-            f.selectAll("input, select").each(function (idx: number, elem: Element) {
+            f.selectAll("input:not([data-m-ignore='true']), select:not([data-m-ignore='true'])").each(function (idx: number, elem: Element) {
                 (<HTMLElement>elem).val("");
             });
-            f.selectAll("textarea").each(function (idx: number, elem: Element) {
+            f.selectAll("textarea:not([data-m-ignore='true'])").each(function (idx: number, elem: Element) {
                 (<HTMLElement>elem).val("");
             });
-            f.selectAll("input[type='checkbox']").each(function (idx: number, elem: Element) {
+            f.selectAll("input[type='checkbox']:not([data-m-ignore='true'])").each(function (idx: number, elem: Element) {
                 (<HTMLElement>elem).val("");
             });
             self.clearAlerts();


### PR DESCRIPTION
When using both metron form handling and MVC razor, clearForm was clearing fields that had been set with values in razor code