### PR TITLE
Date handling changes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "metron",
-  "version": "2.8.16",
+  "version": "2.8.17",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metronical.metron",
-  "version": "2.8.16",
+  "version": "2.8.17",
   "description": "A lightweight library and front-end framework utilizing data attributes",
   "main": "dist/gen/metron.js",
   "homepage": "https://github.com/metronical/metron",

--- a/src/metron.extenders.ts
+++ b/src/metron.extenders.ts
@@ -600,7 +600,11 @@ HTMLElement.prototype.val = function(val?: string): string {
                     if (metron.globals.requiresDateTimePolyfill && /\d{4}-\d{2}-\d{2}/g.test(val)) {
                         this.value = `${date.slice(5, 7)}/${date.slice(8, 10)}/${date.slice(0, 4)}`;
                     }
-                    else {
+                    else if (metron.globals.requiresDateTimePolyfill && /\d{2}\/\d{2}\/\d{4}/g.test(val)) {
+                        this.value = date;
+                    } else if (/\d{2}\/\d{2}\/\d{4}/g.test(val)) {
+                        this.value = `${date.slice(6, 10)}-${date.slice(0, 2)}-${date.slice(3, 5)}`;
+                    } else {
                         this.value = date;
                     }
                     break;

--- a/src/metron.tools.ts
+++ b/src/metron.tools.ts
@@ -219,7 +219,7 @@ namespace metron {
             return "no";
         }
         export function convertDateStringToDate(datetime: string): Date {
-            if (datetime.indexOf("T") > 0 && datetime.indexOf("-") > 0) {
+            if (datetime.indexOf("T") > 0 && datetime.indexOf("-") > 0 && datetime.toLowerCase().indexOf("gmt") == -1) {
                 let dateString: string = datetime.substring(0, datetime.indexOf("T"));
                 let dateArray: Array<string> = dateString.split("-");
                 let timeString: string = datetime.substring(datetime.indexOf("T") + 1, datetime.length);


### PR DESCRIPTION
When formatting dates, need to handle strings in the format Mon Jul 1 2018 GMT etc etc etc.  Also found that Firefox and Chrome input fields of type date were not getting the correct date string from the val() extender